### PR TITLE
Below shows what has been updated in this commit:

### DIFF
--- a/inFileManagement.py
+++ b/inFileManagement.py
@@ -108,9 +108,17 @@ class InFileManagementPopupWindow(Popup):
             for id in ids:
                 # print("    " + id)
                 if key == id.split("-")[0] and "-" in id: # split id string to keep the part that is same as the keys in the entryDataDict 
+                    """
+                    * 2version keyword inside a id means the widget of this id can be either a list or a string
+                    * when reading this kind of data from a in file, need to determine which version should be use to approrate put this data in both entryDataDict and inFileDetails window widget.
+                    """
                     if type(entryDataDict[key]) == list: # if the value of the key in the entryDataDict is a list
+                        if "2version" in id:
+                            localKey = key + "-2version_"
+                        else:
+                            localKey = key + "-"
                         for i in range(len(entryDataDict[key])):
-                            ids[key + "-text_{}".format(i)].text = entryDataDict[key][i]
+                            ids[localKey + "text_{}".format(i)].text = entryDataDict[key][i]
                         break
                     else:
                         if "check" in id: # if the widget of the id is a Checkbox
@@ -119,10 +127,12 @@ class InFileManagementPopupWindow(Popup):
                         elif "spinner" in id: # if the widget of the id is a Spinner
                             ids[key + "-spinner"].text = entryDataDict[key]
                             break
+                        elif "2version" in id: # if current data version from in file is a single string
+                            ids[key + "-2version_text_0"].text = entryDataDict[key] # this line will triggle typeInsideTextInput() of meshAndSimuControl class so that the data will be convert into a list
+                            break
                         else: # if the widget of the id is a single TextInput
                             ids[key + "-"].text = entryDataDict[key]
                             break
-            # print(len(entryDataDict))
 
     
 class InFileChooser(FileChooserListView):

--- a/meshAndSimuControl.kv
+++ b/meshAndSimuControl.kv
@@ -323,19 +323,19 @@
     BlackLabel:
         text: "steady_monitor:"
     Spinner:
-        id: steady_monitor-text_0 
+        id: steady_monitor-2version_text_0 
         text: ""
         values: ["0", "1", "2"]
         # on_text: root.spinnerClicked("steady_monitor", self.text)
         on_text: root.typeInsideTextInput("steady_monitor", self.text, seqLen=3, idxOfCurrentTextIpt=0)
         option_cls: "CustomizedSpinnerOption"
     TextInput:
-        id: steady_monitor-text_1    
+        id: steady_monitor-2version_text_1    
         text: ""
         multiline: False    
         on_text: root.typeInsideTextInput("steady_monitor", self.text, seqLen=3, idxOfCurrentTextIpt=1)
     TextInput:
-        id: steady_monitor-text_2  
+        id: steady_monitor-2version_text_2  
         text: ""
         multiline: False    
         on_text: root.typeInsideTextInput("steady_monitor", self.text, seqLen=3, idxOfCurrentTextIpt=2)

--- a/meshAndSimuControl.py
+++ b/meshAndSimuControl.py
@@ -29,14 +29,23 @@ class MeshAndSimuControlLayout(GridLayout):
     * Kwarg seqLen: if it is larger than 0, it means a series of textInputs will be wrapped into a list to assgin to a single key in the entryDataDict
     * Kwarg idxOfCurrentTextIpt represents the index for the current editing textInput inside the list of the series fo textInputs
     """
-    def typeInsideTextInput(self, key, value, *, seqLen = 0, idxOfCurrentTextIpt = -1):
-        if seqLen > 0:
+    def typeInsideTextInput(self, key, value, *, seqLen = 1, idxOfCurrentTextIpt = -1):
+        if seqLen > 1:
             if key in entryDataDict:
-                listOfValues = entryDataDict[key]
-                listOfValues[idxOfCurrentTextIpt] = value
+                """
+                * For the id that contains 2version, whose value can be either a LIST or a single STRING,
+                * when the entry of this id in entryDataDict trys to show on inFileDetails window,
+                * first check if this entry is a list:
+                *     If it is, re-update this list[indxOfCurrentTextIpt] while initializing the value of this id in inFileDetails window;
+                *     If it is not, convert this entry into a list with a length of arg:seqLen and the first item is the arg:value.   
+                """
+                if type(entryDataDict[key]) == list:
+                    entryDataDict[key][idxOfCurrentTextIpt] = value
+                else:
+                    entryDataDict[key] = [value if i == 0 else "" for i in range(seqLen) ]
             else:
                 entryDataDict[key] = ["" for i in range(seqLen)]
                 entryDataDict[key][idxOfCurrentTextIpt] = value
         else:
             entryDataDict[key] = value
-        # print(entryDataDict)
+        print(entryDataDict["steady_monitor"])

--- a/solverChooserPopup.kv
+++ b/solverChooserPopup.kv
@@ -3,7 +3,7 @@
 <SolverChooserPopup>:
     title: 'Choose Solver'    
     auto_dismiss: False
-    size_hint: (0.6, 0.5)
+    size_hint: (0.6, 0.7)
     pos_hint: {"center_x": 0.5, "top": 0.9}
 
     BoxLayout:
@@ -13,7 +13,15 @@
         spacing: 10
 
         MyButton:
+            text: "Scalar Transport Solver"        
+        MyButton:
             text: "Incompressable Flow Solver"
+        MyButton:
+            text: "Compressible Flow Solver"
+        MyButton:
+            text: "Megnetohydrodynics (MHD) Solver"    
+        MyButton:
+            text: "Shallow Water Solver"    
         MyButton:
             text: "Space Charge Solver"
             on_release: root.gotoInDetails() 
@@ -22,7 +30,6 @@
         MyButton:
             text: "Mesh Moving Solver"
         MyButton:
-            text: "Compressible flow Solver"
-        MyButton:
-            text: "Scalar transport Solver"        
+            text: "Mesh Smoothing Solver"
+
 


### PR DESCRIPTION
Fixed the bug:
    - Data of steady_monitor from in file could be either a single string or a list, in these case current id catalog can not handle these problem.
    - So we add a new id catalog containing keyword "2version" which will be used to handle above issue.

New feature:
    + Added 3 new solvers into the solverChooserPopup(Popup) widget.

File update:
    inFileManagement.py:
        1. Modified showDataToInFileDetailsWindow(self, *, theWindow) to handle 2version id.

    meshAndSimuControl.kv:
        1. Changed id under steady_monitor into steady_monitor-2version_text_#.

    meshAndSimuControl.py:
        1. Modified typeInsideTextInput(self, key, value, *, seqLen = 1, idxOfCurrentTextIpt = -1) to be able to convert steady_monitor entry into a list if it is not when ready from a in file.

    solverChooserPopup.kv:
        1. Added new solver buttons.